### PR TITLE
Update release workflow for npm and Node.js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ env:
   GITHUB_ACTOR: "hyperledger-bot"
   GITHUB_ACTOR_EMAIL: "hyperledger-bot@hyperledger.org"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
   OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
   OSSRH_GPG_SECRET_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
@@ -20,6 +19,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write # Required for npm trusted publishing (OIDC)
 
 jobs:
   release:
@@ -33,7 +33,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: 22
+          registry-url: "https://registry.npmjs.org/"
+
+      # Ensure npm version >= 11.5.1 (lowest supporting trusted publishing)
+      - name: Upgrade npm
+        run: npm install -g npm@^11.5.1
 
       - name: "Install Java ${{ env.JAVA_VERSION }}"
         uses: actions/setup-java@v4
@@ -44,7 +49,6 @@ jobs:
           server-username: ${{ secrets.OSSRH_USERNAME }}
           server-password: ${{ secrets.OSSRH_PASSWORD }}
 
-
       - uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
@@ -54,6 +58,9 @@ jobs:
           git_commit_gpgsign: true
           git_config_global: true
           git_tag_gpgsign: false
+
+      - name: Install Dependencies
+        run: npm ci
 
       - name: "Release"
         env:


### PR DESCRIPTION
Removed NPM_TOKEN from environment variables and updated Node.js version to 22. Added npm upgrade step and ensured npm version is >= 11.5.1 for trusted publishing.
